### PR TITLE
Change Search results background

### DIFF
--- a/style.css
+++ b/style.css
@@ -562,9 +562,10 @@ header .song_slide nav .search::before {
 }
 
 header .song_slide nav .search .search_results {
+    background-color: var(--song-slide-bg);
     position: absolute;
     width: 100%;
-    height: 200px;
+    max-height: 200px;
     /* border:1px solid; */
     margin-top: 26px;
     border-radius: 7px;
@@ -576,6 +577,7 @@ header .song_slide nav .search .search_results::-webkit-scrollbar {
 }
 
 header .song_slide nav .search .search_results .card {
+    border-radius: 5px;
     width: 100%;
     min-height: 30px;
     /* border:1px solid white; */
@@ -743,17 +745,14 @@ header .song_slide .content .buttons button:nth-child(2):hover {
     color: #fff;
 }
 
-.song_card{
-    position: relative;
-    z-index: -1;
-}
-
 header .song_slide .song_card {
     width: 90%;
     height: auto;
     /* border:1px solid #fff; */
     margin: auto;
     margin-top: 15px;
+    position: relative;
+    z-index: -1;
 }
 
 header .song_slide .song_card .h4 {


### PR DESCRIPTION
I have now made changes to the search results element making it clearly visible than before.
Before:
<img width="239" alt="Screenshot 2023-10-04 175710" src="https://github.com/adityakmrmishra/Geet/assets/116891059/454c349b-0f7d-4163-a4a4-25552d034d51">

After:
<img width="206" alt="Screenshot 2023-10-05 080728" src="https://github.com/adityakmrmishra/Geet/assets/116891059/f4c8061e-a1c6-4b83-879e-1b67582f75e7">
<img width="177" alt="Screenshot 2023-10-05 080736" src="https://github.com/adityakmrmishra/Geet/assets/116891059/704c7114-36d3-4e3d-9d6f-c4de5826a91c">

closes #30 